### PR TITLE
Revert "device.mk: remove pktrouter.mk references"

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -634,6 +634,9 @@ PRODUCT_PACKAGES += \
 	cplay
 endif
 
+## Start packet router
+include device/google/gs101/telephony/pktrouter.mk
+
 # EdgeTPU
 include device/google/gs-common/edgetpu/edgetpu.mk
 # Config variables for TPU chip on device.


### PR DESCRIPTION
This reverts commit d94758cb13a8b20d83d32ab3c57ba09b3797f01b.

Reason: Previously, the inclusion of pktrouter.mk from device/google/gs101 was causing builds to fail. This is no longer the case, so add back pktrouter.mk.